### PR TITLE
fixed broken require stmt due to case

### DIFF
--- a/modules/multipart/index.js
+++ b/modules/multipart/index.js
@@ -1,5 +1,5 @@
 exports.Parser = require('./parser');
-exports.Part = require('./Part');
+exports.Part = require('./part');
 
 var assert = require('assert');
 


### PR DESCRIPTION
The multipart module was trying to import ./Part, which was breaking on my case-sensitive Linux install. Changed it to be lowercase to match the file name.
