### PR TITLE
Make native microtime module optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "rsvp": "~3.0.6",
     "mime": "~1.2.9",
     "strftime": "~0.5.0",
-    "microtime": "~0.4.0",
     "qs": "~0.6.5"
   },
   "optionalDependencies": {
+    "microtime": "~0.4.0",
     "then-redis": "~0.3.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Couldn't install with node v0.11.13 because microtime failed to build. Made it optional.
