### PR TITLE
fix: allow calling setCookie() multiple times

### DIFF
--- a/modules/Message.js
+++ b/modules/Message.js
@@ -222,7 +222,11 @@ Object.defineProperties(Message.prototype, {
     headerName = normalizeHeaderName(headerName);
 
     if (headerName in this.headers) {
-      this.headers[headerName] = [ this.headers[headerName], value ].join('\n');
+      if (Array.isArray(this.headers[headerName])) {
+        this.headers[headerName].push(value);
+      } else {
+        this.headers[headerName] = [this.headers[headerName], value];
+      }
     } else {
       this.headers[headerName] = value;
     }

--- a/spec/message-spec.js
+++ b/spec/message-spec.js
@@ -1,0 +1,39 @@
+require('./helper');
+var Message = mach.Message;
+
+describe('A mach.Message', function () {
+  var message;
+  beforeEach(function () {
+    message = new Message;
+  });
+
+  describe('addHeader', function () {
+
+    it('normalizes header names', function () {
+      message.addHeader('content-type', 'text/html');
+      expect(message.headers['Content-Type']).toEqual('text/html');
+    });
+
+    describe('when the header has not been previously set', function () {
+      it('sets the header to the given value', function () {
+        message.addHeader('Test', 'value');
+        expect(message.headers['Test']).toEqual('value');
+
+        message.addHeader('Test-Int', 1);
+        expect(message.headers['Test-Int']).toEqual(1);
+      });
+    });
+
+    describe('when the header has been previously set', function () {
+      beforeEach(function () {
+        message.addHeader('Test', 'previousValue');
+      });
+
+      it('sets the header to an array of header values', function () {
+        message.addHeader('Test', 'value');
+        expect(message.headers['Test']).toEqual(['previousValue', 'value']);
+      });
+
+    });
+  });
+});

--- a/spec/response-spec.js
+++ b/spec/response-spec.js
@@ -1,0 +1,35 @@
+require('./helper');
+var Response = mach.Response;
+
+describe('A mach.Response', function () {
+  var response;
+  beforeEach(function () {
+    response = new Response;
+  });
+
+  describe('setCookie', function () {
+    describe('when no cookies have been previously set', function () {
+      it('sets the "Set-Cookie" header to the appropriate string', function () {
+        response.setCookie('cookieName', {value: 'cookieValue'});
+
+        expect(response.headers['Set-Cookie']).toEqual('cookieName=cookieValue');
+      });
+    });
+
+    describe('when cookies have been previously set', function () {
+      beforeEach(function () {
+        response.setCookie('previousOne', {value: 'previousOneValue'});
+      });
+
+      it('sets the "Set-Cookie" header to an array of headers', function () {
+        response.setCookie('cookieName', {value: 'cookieValue'});
+
+        expect(response.headers['Set-Cookie']).toEqual([
+          'previousOne=previousOneValue',
+          'cookieName=cookieValue',
+        ]);
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Setting multiple cookies by separating them with a newline didn't work for me. Node's http.request supports multiple headers by passing an array, so I used that solution.
