### PR TITLE
Add support for with credentials to be passed via a request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Improvements:
   * Add Request#bufferContent and Request#stringifyContent
   * Add Request#search
   * Request#call always returns a Response
+  * Pass withCredentials through when making requests as a client
 
 ### 0.12.0 / 2014-07-17
 

--- a/modules/Request.js
+++ b/modules/Request.js
@@ -69,6 +69,8 @@ function Request(options) {
   this.scriptName = options.scriptName || '';
   this.pathInfo = options.pathInfo || options.path || '';
 
+  if(options.hasOwnProperty('withCredentials')) this.withCredentials = options.withCredentials;
+
   // Make sure pathInfo is at least '/'.
   if (this.scriptName === '' && this.pathInfo === '')
     this.pathInfo = '/';

--- a/modules/utils/createProxy.js
+++ b/modules/utils/createProxy.js
@@ -33,7 +33,7 @@ function createProxy(options) {
   var path = options.path || '';
 
   return function (request) {
-    return sendRequest({
+    var requestOptions = {
       method: request.method,
       protocol: protocol,
       auth: auth,
@@ -42,7 +42,11 @@ function createProxy(options) {
       path: path,
       headers: request.headers,
       content: request.content
-    });
+    };
+
+    if(options.hasOwnProperty('withCredentials')) requestOptions.withCredentials = options.withCredentials;
+
+    return sendRequest(requestOptions);
   };
 }
 

--- a/specs/Request-spec.js
+++ b/specs/Request-spec.js
@@ -3,6 +3,26 @@ var MaxLengthExceededError = require('../modules/utils/MaxLengthExceededError');
 var Request = mach.Request;
 
 describe('Request', function () {
+
+  describe('withCredentials', function() {
+    it('does not have withCredentials if it was not set', function() {
+      var request = new Request({});
+      expect(request.hasOwnProperty('withCredentials')).toEqual(false);
+    });
+
+    it('has with credentials when it is set', function() {
+      var request = new Request({ withCredentials: false });
+      expect(request.hasOwnProperty('withCredentials')).toEqual(true);
+      expect(request.withCredentials).toEqual(false);
+    });
+
+    it('has with credentials when it is set to true', function() {
+      var request = new Request({ withCredentials: true });
+      expect(request.hasOwnProperty('withCredentials')).toEqual(true);
+      expect(request.withCredentials).toEqual(true);
+    });
+  });
+
   describe('that uses https', function () {
     describe('on the standard port', function () {
       it('does not include the port # in host', function () {


### PR DESCRIPTION
Adds a withCredentials pass through when making requests.
