### PR TITLE
update deprecated invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "8"
 services:
   - redis-server
 env: WITH_REDIS=1

--- a/modules/utils/makeTemporaryPath.js
+++ b/modules/utils/makeTemporaryPath.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var TMP_DIR = require('os').tmpDir();
+var TMP_DIR = require('os').tmpdir();
 
 function makeTemporaryPath(prefix) {
   prefix = prefix || '';


### PR DESCRIPTION
Hi there,  
Could you update the method invocation in `makeTemporaryPath.js`.  
```
[DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```